### PR TITLE
Fix dev container actionlint URL

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
+ARG ACTIONLINT_VERSION=1.7.7
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     curl \
@@ -7,7 +8,7 @@ RUN apt-get update \
     shellcheck \
     shfmt \
     ca-certificates \
-  && curl -fsSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_linux_amd64.tar.gz \
+  && curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
     | tar xz -C /usr/local/bin actionlint \
   && chmod +x /usr/local/bin/actionlint \
   && apt-get clean \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install tools
         run: brew install shellcheck shfmt actionlint


### PR DESCRIPTION
## Summary
- fix actionlint download in dev container
- update checkout action version

## Testing
- `shfmt -d setup`
- `shellcheck setup`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_6867c16c8d208326b9537eba6789656d

## Summary by Sourcery

Fix actionlint installation in the development container by parameterizing its version and update the CI checkout action to v4

Bug Fixes:
- Correct the actionlint download URL in the devcontainer Dockerfile to reference the specified version

Enhancements:
- Introduce an ACTIONLINT_VERSION build argument for configurable actionlint version in the Dockerfile

CI:
- Bump the GitHub Actions checkout action from v3 to v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker configuration to allow specifying the version of the `actionlint` tool, ensuring consistent builds.
  * Updated the continuous integration workflow to use the latest version of the `actions/checkout` action for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->