### PR TITLE
Update README with Mackup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,26 @@ git clone https://github.com/EpicKris/setup-macos.git ~/.setup-macos && ~/.setup
 
 2. [Visual Studio Code][visual-studio-code] as a text editor.
 
-3. A set of relevant apps…
+3. Automatic dotfile restore via Mackup.
+
+4. A set of relevant apps…
 	- [Firefox][firefox]
 	- [Google Chrome][google-chrome]
 	- [IINA][iina]
 
+
+This setup relies on [Mackup](https://github.com/lra/mackup) with iCloud to sync your dotfiles.
+
 See [`apps/app-store`](apps/app-store) and [`apps/cask`](apps/cask) for the full list of apps that will be installed.
 Adjust it to your personal taste.
 Lines starting with `#` in these files are ignored, so you can comment out apps you don't want.
+Keep the entries sorted alphabetically when you modify these lists.
 
 [firefox]: https://firefox.com
 [google-chrome]: https://chrome.google.com
 [iina]: https://iina.io
 [nginx]: https://nginx.org
-[swift]: https://swift.sorting
+[swift]: https://swift.org
 [visual-studio-code]: https://code.visualstudio.com
 
 ## Development Container


### PR DESCRIPTION
## Summary
- describe automatic dotfile restore with Mackup
- note alphabetized app lists
- fix Swift URL

## Testing
- `shellcheck setup`
- `shfmt -i 2 -ci -d setup`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_6877e87343fc8326ad2a6e9cdad047df

## Summary by Sourcery

Document automatic dotfile restore with Mackup, enforce alphabetical app lists, and correct the Swift URL in the README

Documentation:
- Add Mackup dotfile restore description with iCloud sync instructions
- Add note to keep app entries sorted alphabetically
- Fix Swift URL to use the official swift.org domain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to highlight automatic dotfile restore via Mackup and clarified its use with iCloud.
  * Corrected the Swift URL and recommended keeping app lists alphabetically sorted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->